### PR TITLE
Relax regex on nodename to match current master

### DIFF
--- a/lib/facter/rabbitmq_nodename.rb
+++ b/lib/facter/rabbitmq_nodename.rb
@@ -2,7 +2,7 @@ Facter.add(:rabbitmq_nodename) do
   setcode do
     if Facter::Core::Execution.which('rabbitmqctl')
       rabbitmq_nodename = Facter::Core::Execution.execute('rabbitmqctl status 2>&1')
-      %r{^Status of node '?([\w\.]+@[\w\.\-]+)'? \.+$}.match(rabbitmq_nodename)[1]
+      %r{^Status of node '?([\w\.\-]+@[\w\.\-]+)'?}.match(rabbitmq_nodename)[1]
     end
   end
 end


### PR DESCRIPTION
Fixes ```puppet
Error: Facter: error while resolving custom fact "rabbitmq_nodename": undefined method `[]' for nil:NilClass
```
