### PR TITLE
Add new parameter skip_munging for rabbitmq_parameter

### DIFF
--- a/lib/puppet/type/rabbitmq_parameter.rb
+++ b/lib/puppet/type/rabbitmq_parameter.rb
@@ -19,6 +19,18 @@ Type for managing rabbitmq parameters
          'expires' => '360000',
      },
    }
+   rabbitmq_parameter { 'documentumShovelNoMunging@/':
+     component_name => '',
+     value          => {
+         'src-uri'    => 'amqp://',
+         'src-exchange'  => 'my-exchange',
+         'src-exchange-key' => '6',
+         'src-queue'  => 'my-queue',
+         'dest-uri'   => 'amqp://remote-server',
+         'dest-exchange' => 'another-exchange',
+     },
+     skip_munging   => true,
+   }
 DESC
 
   ensurable do
@@ -50,6 +62,12 @@ DESC
     end
   end
 
+  newparam(:skip_munging) do
+    desc 'Set to true to disable conversion from number strings to integers'
+    defaultto(:false)
+    newvalues(:true, :false)
+  end
+
   newproperty(:value) do
     desc 'A hash of values to use with the component name you are setting'
     validate do |value|
@@ -78,6 +96,7 @@ DESC
   end
 
   def munge_value(value)
+    return value if self[:skip_munging] == :true
     value.each do |k, v|
       value[k] = v.to_i if v =~ %r{\A[-+]?[0-9]+\z}
     end

--- a/spec/unit/puppet/type/rabbitmq_parameter_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_parameter_spec.rb
@@ -82,4 +82,12 @@ describe Puppet::Type.type(:rabbitmq_parameter) do
     parameter[:value] = value
     expect(parameter[:value]['myparameter']).to eq(1_800_000)
   end
+
+  it 'does not munge the value when skip_munging is set to true' do
+    parameter[:skip_munging] = true
+    value = { 'myparameter' => '1800000' }
+    parameter[:value] = value
+    expect(parameter[:value]['myparameter']).to eq('1800000')
+    expect(parameter[:value]['myparameter']).to be_kind_of(String)
+  end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

Add new parameter `skip_munging` for `rabbitmq_parameter` to prevent numberic strings from being converted to integers. 

#### This Pull Request (PR) fixes the following issues

We have several `x-content-hash` exchanges which use a numeric string as the routing key. As a result, shovels for these exchanges would include key value pairs like this `"src-exchange-key": "5"`. By default the string `"5"` will be converted to an integer. However, RabbitMQ doesn't accept exchange keys to be integers. As a result, we'd run into errors from RabbitMQ
```
Error:
Validation failed
dest-exchange-key should be binary, actually was 5
src-exchange-key should be binary, actually was 5
```

This PR would allow the auto type conversion to be disabled and therefore numeric strings to be included in the RabbitMQ parameter payload if needed.

